### PR TITLE
Update Assembler.py

### DIFF
--- a/Assembler.py
+++ b/Assembler.py
@@ -309,6 +309,8 @@ while(i<len(l)):
             inst = instr
         if(len(instr)>0):
             OpCode=Assembler(inst)
+        else:
+            OpCode=""
         if("ERROR" in OpCode):
             clear()
             instr_list.pop()

--- a/Assembler.py
+++ b/Assembler.py
@@ -310,7 +310,7 @@ while(i<len(l)):
         if(len(instr)>0):
             OpCode=Assembler(inst)
         else:
-            OpCode=""
+            continue
         if("ERROR" in OpCode):
             clear()
             instr_list.pop()


### PR DESCRIPTION
Removed extra Opcode being generated due to blank line in instruction. After instructions a line is left blank before .memcheck due to this blank line the last opcode will be printed twicw in the pm_file. This issue is rectified.